### PR TITLE
Update utility function name that was causing an issue when trying to use this Framework in Swift.

### DIFF
--- a/KTMImageBrowser/Classes/KTMImageBrowserViewController.h
+++ b/KTMImageBrowser/Classes/KTMImageBrowserViewController.h
@@ -66,6 +66,6 @@
  *  Use this utility function to create an instance of KTMImageBrowserViewController *.
  *  @return Instance of KTMImageBrowserViewController *.
  */
-+ (nullable instancetype)imageBrowserViewController;
++ (nullable instancetype)browserView;
 
 @end

--- a/KTMImageBrowser/Classes/KTMImageBrowserViewController.m
+++ b/KTMImageBrowser/Classes/KTMImageBrowserViewController.m
@@ -35,7 +35,7 @@
 
 @implementation KTMImageBrowserViewController
 
-+ (nullable instancetype)imageBrowserViewController
++ (nullable instancetype)browserView
 {
     NSBundle *bundle = [self bundleOfThisPod];
     if (bundle)


### PR DESCRIPTION
- The issue is that the function name, cannot match the classe name, otherwise it will be removed. For example:
If you have a classe named MyClassViewController, if you create a method called "testViewController", it will be renamed to "test" only, because viewController matches the last part of the class name.